### PR TITLE
Added global configuration support

### DIFF
--- a/lib/translate_enum.rb
+++ b/lib/translate_enum.rb
@@ -2,6 +2,7 @@ require 'active_support/concern'
 require 'active_support/core_ext/string'
 require 'translate_enum/version'
 require 'translate_enum/builder'
+require 'translate_enum/config'
 
 module TranslateEnum
   extend ActiveSupport::Concern

--- a/lib/translate_enum/builder.rb
+++ b/lib/translate_enum/builder.rb
@@ -21,7 +21,7 @@ module TranslateEnum
 
     # like "activerecord.attributes" or "activemodel.attributes"
     def i18n_scope
-      @i18n_scope ||= "#{model.i18n_scope}.attributes"
+      @i18n_scope ||= TranslateEnum.config.i18n_scope || "#{model.i18n_scope}.attributes"
     end
 
     def i18n_key

--- a/lib/translate_enum/config.rb
+++ b/lib/translate_enum/config.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module TranslateEnum
+  # Global configuration support for TranslateEnum
+  #   TranslateEnum.configure do |config|
+  #     config.i18n_scope = 'translate_enum'
+  #   end
+  class << self
+    def configure
+      yield config
+    end
+
+    def config
+      @_config ||= Config.new
+    end
+  end
+
+  class Config
+    attr_accessor :i18n_scope
+
+    def initialize
+      @i18n_scope = nil
+    end
+  end
+end


### PR DESCRIPTION
Hi I needed to add global configuration support for an app that I was working on, had lots of lists and the activerecord.attributes file started to feel too clogged, but also didn't want to add a block for each class on the translate_enum methods. It could be useful in the future to easily add new global settings. Let me know if you are interested in adding this to the project, I tried to change as little as possible, but it could use some improvements.

	# config/initializers/translate_enum_config.rb
	TranslateEnum.configure do |config|
	    config.i18n_scope = 'translate_enums'
	end


then call the configuration like
	
	TranslateEnum.config.i18n_scope